### PR TITLE
Fix table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Install library via `npm`
 First you need to build `RowRepository` with data:
 
 ```js
-    const data = [
-      {
-        id: 1,
-        name: 'Column1',
-        rows: [
+const data = [
+  {
+    id: 1,
+    name: 'Column1',
+    rows: [
       { id: 1, name: 'Item1' },
       { id: 2, name: 'Item2' },
       { id: 3, name: 'Item3' },
@@ -64,14 +64,14 @@ Then you can render the `Board`:
   />
 ```
 
-      Property      |       Type      |  Required | Description
---------------------|-----------------|-----------|------------
-rowRepository       | `RowRepository` |    yes    | object that holds data
-renderRow           | `function`      |    yes    | function responsible for rendering row item
-renderColumnWrapper | `function`      |    no     | function responsible for rendering wrapper of the column if needed
-open                | `function`      |    no     | function invoked when item pressed
-onDragEnd           | `function`      |    no     | function invoked when drag is finished
-style               | `object`        |    no     | custom styles for the board `ScrollView`
+|      Property      |       Type      |  Required | Description |
+|--------------------|-----------------|-----------|-------------|
+|rowRepository       | `RowRepository` |    yes    | object that holds data |
+|renderRow           | `function`      |    yes    | function responsible for rendering row item|
+|renderColumnWrapper | `function`      |    no     | function responsible for rendering wrapper of the column if needed|
+|open                | `function`      |    no     | function invoked when item pressed|
+|onDragEnd           | `function`      |    no     | function invoked when drag is finished|
+|style               | `object`        |    no     | custom styles for the board `ScrollView`|
 
 
 # Example


### PR DESCRIPTION
I just changed the formatting to render it as a table. You forgot to add the `|` before and after each row.

| table header 1 | table header 2 | table header 3 |
| ----- | ----- | ----- |
| table cell 1 | table cell 2 | table cell 3 |

Also changed the tabs for the sample `const data`