### PR TITLE
Expose contentContainerStyle from ScrollView

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,15 @@ Then you can render the `Board`:
   />
 ```
 
-|      Property      |       Type      |  Required | Description |
-|--------------------|-----------------|-----------|-------------|
-|rowRepository       | `RowRepository` |    yes    | object that holds data |
-|renderRow           | `function`      |    yes    | function responsible for rendering row item|
-|renderColumnWrapper | `function`      |    no     | function responsible for rendering wrapper of the column if needed|
-|open                | `function`      |    no     | function invoked when item pressed|
-|onDragEnd           | `function`      |    no     | function invoked when drag is finished|
-|style               | `object`        |    no     | custom styles for the board `ScrollView`|
+| Property | Type | Required | Description |
+| :--- | :--- | :---: | :--- |
+| rowRepository | `RowRepository` | yes | object that holds data |
+| renderRow | `function` | yes | function responsible for rendering row item |
+| renderColumnWrapper | `function` | no | function responsible for rendering wrapper of the column if needed |
+| open | `function` | no | function invoked when item pressed |
+| onDragEnd | `function` | no | function invoked when drag is finished |
+| style | `object` | no | styles for the internal `ScrollView`|
+| contentContainerStyle | `object` | no | contentContainerStyle for the internal `ScrollView` |
 
 
 # Example

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -273,6 +273,7 @@ class Board extends React.Component {
     return (
       <ScrollView
         style={this.props.style}
+        contentContainerStyle={this.props.contentContainerStyle}
         scrollEnabled={!this.state.movingMode}
         onScroll={this.onScroll.bind(this)}
         onScrollEndDrag={this.onScrollEnd.bind(this)}


### PR DESCRIPTION
`ScrollView` has a [`contentContainerStyle`](https://facebook.github.io/react-native/docs/scrollview.html#contentcontainerstyle) props which is used to style the internal container of `ScrollView`. This will expose that props to other developers.

From the docs:
> These styles will be applied to the scroll view content container which wraps all of the child views.